### PR TITLE
Check if anim dict exists for emote

### DIFF
--- a/Client/Emote.lua
+++ b/Client/Emote.lua
@@ -355,6 +355,7 @@ function OnEmotePlay(EmoteName)
 
   if not LoadAnim(ChosenDict) then
     EmoteChatMessage("'".. ename .."' "..Config.Languages[lang]['notvalidemote'].."")
+    return
   end
 
   if EmoteName.AnimationOptions then

--- a/Client/Emote.lua
+++ b/Client/Emote.lua
@@ -225,10 +225,16 @@ function EmoteCommandStart(source, args, raw)
 end
 
 function LoadAnim(dict)
+  if not DoesAnimDictExist(dict) then
+    return false
+  end
+
   while not HasAnimDictLoaded(dict) do
     RequestAnimDict(dict)
     Wait(10)
   end
+
+  return true
 end
 
 function LoadPropDict(model)
@@ -347,7 +353,9 @@ function OnEmotePlay(EmoteName)
     return end 
   end
 
-  LoadAnim(ChosenDict)
+  if not LoadAnim(ChosenDict) then
+    EmoteChatMessage("'".. ename .."' "..Config.Languages[lang]['notvalidemote'].."")
+  end
 
   if EmoteName.AnimationOptions then
     if EmoteName.AnimationOptions.EmoteLoop then


### PR DESCRIPTION
Adds a check for whether the animation dictionary for an emote exists in
the current gamebuild, so that invalid dictionary names or ones that
only exist in newer gamebuilds don't cause the resource to get stuck
waiting for the dictionary to load.