### PR TITLE
Add support for persistent walkstyles

### DIFF
--- a/client/Walk.lua
+++ b/client/Walk.lua
@@ -1,6 +1,5 @@
 function WalkMenuStart(name)
     TriggerEvent('dpemotes:client:SaveWalkstyle', name)
-    TriggerServerEvent('dpemotes:server:SaveWalkstyle', name)
     RequestWalking(name)
     SetPedMovementClipset(PlayerPedId(), name, 0.2)
     RemoveAnimSet(name)
@@ -50,21 +49,18 @@ if Config.WalkingStylesEnabled and Config.PersistentWalk then
         SetResourceKvp('walkstyle', walkstyle)
     end)
 
-    RegisterNetEvent('dpemotes:client:ApplyWalkstyle')
-    AddEventHandler('dpemotes:client:ApplyWalkstyle', function(walkstyle)
-        WalkMenuStart(walkstyle)
+    RegisterNetEvent('dpemotes:client:ApplySavedWalkstyle')
+    AddEventHandler('dpemotes:client:ApplySavedWalkstyle', function()
+        local walkstyle = GetResourceKvpString('walkstyle')
+
+        if walkstyle then
+            WalkMenuStart(walkstyle)
+        end
     end)
 
     CreateThread(function()
         while true do
-            local walkstyle = GetResourceKvpString('walkstyle')
-
-            if walkstyle then
-                TriggerEvent('dpemotes:client:ApplyWalkstyle', walkstyle)
-            else
-                TriggerServerEvent('dpemotes:server:ApplyWalkstyle')
-            end
-
+            TriggerEvent('dpemotes:client:ApplySavedWalkstyle')
             Wait(Config.PersistencePollPeriod)
         end
     end)

--- a/client/Walk.lua
+++ b/client/Walk.lua
@@ -1,4 +1,6 @@
 function WalkMenuStart(name)
+    TriggerEvent('dpemotes:client:SaveWalkstyle', name)
+    TriggerServerEvent('dpemotes:server:SaveWalkstyle', name)
     RequestWalking(name)
     SetPedMovementClipset(PlayerPedId(), name, 0.2)
     RemoveAnimSet(name)
@@ -40,4 +42,30 @@ end
 
 function tableHasKey(table, key)
     return table[key] ~= nil
+end
+
+if Config.WalkingStylesEnabled and Config.PersistentWalk then
+    RegisterNetEvent('dpemotes:client:SaveWalkstyle')
+    AddEventHandler('dpemotes:client:SaveWalkstyle', function(walkstyle)
+        SetResourceKvp('walkstyle', walkstyle)
+    end)
+
+    RegisterNetEvent('dpemotes:client:ApplyWalkstyle')
+    AddEventHandler('dpemotes:client:ApplyWalkstyle', function(walkstyle)
+        WalkMenuStart(walkstyle)
+    end)
+
+    CreateThread(function()
+        while true do
+            local walkstyle = GetResourceKvpString('walkstyle')
+
+            if walkstyle then
+                TriggerEvent('dpemotes:client:ApplyWalkstyle', walkstyle)
+            else
+                TriggerServerEvent('dpemotes:server:ApplyWalkstyle')
+            end
+
+            Wait(Config.PersistencePollPeriod)
+        end
+    end)
 end

--- a/config.lua
+++ b/config.lua
@@ -53,6 +53,10 @@ Config = {
     Search = true,
     -- You can disable the Animal Emotes here.
     AnimalEmotesEnabled = true,
+    -- Saves walk styles to SQL and applies them on player load
+    PersistentWalk = false,
+    -- Polling period to apply persistent walkstyles
+    PersistencePollPeriod = 60000,
 }
 
 Config.KeybindKeys = {

--- a/config.lua
+++ b/config.lua
@@ -53,7 +53,7 @@ Config = {
     Search = true,
     -- You can disable the Animal Emotes here.
     AnimalEmotesEnabled = true,
-    -- Saves walk styles to SQL and applies them on player load
+    -- Saves walk styles to client and applies them periodically
     PersistentWalk = false,
     -- Polling period to apply persistent walkstyles
     PersistencePollPeriod = 60000,

--- a/server/Server.lua
+++ b/server/Server.lua
@@ -169,3 +169,27 @@ if Config.SqlKeybinding and MySQL then
 else
     print("[dp] ^3Sql Keybinding^7 is turned ^1off^7, if you want to enable /emotebind, set ^3SqlKeybinding = ^2true^7 in config.lua and uncomment oxmysql lines in fxmanifest.lua.")
 end
+
+-----------------------------------------------------------------------------------------------------
+-- Persistent Walkstyles  ---------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------------
+
+if Config.WalkingStylesEnabled and Config.PersistentWalk then
+    RegisterServerEvent("dpemotes:server:SaveWalkstyle")
+    AddEventHandler("dpemotes:server:SaveWalkstyle", function(walkstyle)
+        local playerName = GetPlayerName(source)
+
+        SetResourceKvp(playerName..'_walkstyle', walkstyle)
+    end)
+
+    RegisterNetEvent("dpemotes:server:ApplyWalkstyle")
+    AddEventHandler("dpemotes:server:ApplyWalkstyle", function()
+        local src = source
+        local playerName = GetPlayerName(src)
+        local walkstyle = GetResourceKvpString(playerName..'_walkstyle')
+
+        if walkstyle then
+            TriggerClientEvent('dpemotes:client:ApplyWalkstyle', src, walkstyle)
+        end
+    end)
+end

--- a/server/Server.lua
+++ b/server/Server.lua
@@ -169,27 +169,3 @@ if Config.SqlKeybinding and MySQL then
 else
     print("[dp] ^3Sql Keybinding^7 is turned ^1off^7, if you want to enable /emotebind, set ^3SqlKeybinding = ^2true^7 in config.lua and uncomment oxmysql lines in fxmanifest.lua.")
 end
-
------------------------------------------------------------------------------------------------------
--- Persistent Walkstyles  ---------------------------------------------------------------------------
------------------------------------------------------------------------------------------------------
-
-if Config.WalkingStylesEnabled and Config.PersistentWalk then
-    RegisterServerEvent("dpemotes:server:SaveWalkstyle")
-    AddEventHandler("dpemotes:server:SaveWalkstyle", function(walkstyle)
-        local playerName = GetPlayerName(source)
-
-        SetResourceKvp(playerName..'_walkstyle', walkstyle)
-    end)
-
-    RegisterNetEvent("dpemotes:server:ApplyWalkstyle")
-    AddEventHandler("dpemotes:server:ApplyWalkstyle", function()
-        local src = source
-        local playerName = GetPlayerName(src)
-        local walkstyle = GetResourceKvpString(playerName..'_walkstyle')
-
-        if walkstyle then
-            TriggerClientEvent('dpemotes:client:ApplyWalkstyle', src, walkstyle)
-        end
-    end)
-end


### PR DESCRIPTION
Currently walkstyle animations set by dpemotes will disappear when a ped is unloaded / reloaded. A common scenario where this occurs is on player logout / login - logging in does not apply the last set walkstyle.

This PR adds optional support to dpemotes for saving walkstyles that persist across player logout / login. This is achieved through the use of KVPs and a thread poll.

This was adapted from the work done for #62.